### PR TITLE
Fix tiny typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ manufacturers overlap other manufacturer part numbers.
 [![Donate](https://img.shields.io/badge/Donate-PayPal-gold.svg)](https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=53HWHHVCJ3D4J&currency_code=EUR&source=url)
 
 # What does it do
-`digkey-api` is an [Digkey Part Search API](https://api-portal.digikey.com/node/8517) client for Python 3.6+. API response data is returned as Python objects that attempt to make it easy to get the data you want. Not all endpoints have been implemented.
+`digikey-api` is an [Digkey Part Search API](https://api-portal.digikey.com/node/8517) client for Python 3.6+. API response data is returned as Python objects that attempt to make it easy to get the data you want. Not all endpoints have been implemented.
 
 # Quickstart
 


### PR DESCRIPTION
Fixed tiny typo - 'digkey-api' -> 'digikey-api'