### PR TITLE
WIP: Add configuration/settings storage class.

### DIFF
--- a/digikey/__init__.py
+++ b/digikey/__init__.py
@@ -1,9 +1,6 @@
 import logging
 from digikey.v2.api import (search, part)
-from digikey.v3.api import (keyword_search, product_details, digi_reel_pricing, suggested_parts,
-                            manufacturer_product_details)
-from digikey.v3.api import (status_salesorder_id, salesorder_history)
-from digikey.v3.api import (batch_product_details)
+from digikey.v3.api import DigikeyAPI
 
 logger = logging.getLogger(__name__)
 

--- a/digikey/configfile.py
+++ b/digikey/configfile.py
@@ -1,0 +1,25 @@
+import os
+import json
+
+
+class DigikeyApiConfig:
+    def __init__(self, file_name):
+        self.file_name = file_name
+        # Get config from file if it exists
+        if os.path.exists(self.file_name):
+            with open(self.file_name, 'r') as f:
+                self.config = json.load(f)
+        else:
+            self.config = {}
+
+    def save(self):
+        with open(self.file_name, 'w') as f:
+            json.dump(self.config, f)
+
+    def get(self, what: str):
+        if what in self.config:
+            return self.config[what]
+        return None
+
+    def set(self, what: str, to):
+        self.config[what] = to

--- a/digikey/configfile.py
+++ b/digikey/configfile.py
@@ -2,8 +2,29 @@ import os
 import json
 
 
-class DigikeyApiConfig:
+class DigikeyBaseConfig:
+    """
+        Base class for a configuration handler which saves info related to Digikey's API like the client-ID
+        This class must not be directly used, instead another class that inherits this class. The class that inherits
+        this class must override save(), get(), and set() with the same parameters and returns.
+        Check out DigikeyJsonConfig for more details as to how to do this.
+    """
+    def __init__(self):
+        pass
+
+    def save(self):
+        pass
+
+    def get(self, what: str):
+        pass
+
+    def set(self, what: str, to):
+        pass
+
+
+class DigikeyJsonConfig(DigikeyBaseConfig):
     def __init__(self, file_name):
+        super().__init__()
         self.file_name = file_name
         # Get config from file if it exists
         if os.path.exists(self.file_name):

--- a/digikey/oauth/oauth2.py
+++ b/digikey/oauth/oauth2.py
@@ -37,7 +37,7 @@ logger = logging.getLogger(__name__)
 
 
 class Oauth2Token:
-    def __init__(self, config: configfile.DigikeyApiConfig):
+    def __init__(self, config: configfile.DigikeyBaseConfig):
         self._config = config
 
     @property
@@ -109,7 +109,7 @@ class TokenHandler:
     Functions used to handle Digikey oAuth
     """
     def __init__(self,
-                 dk_config: configfile.DigikeyApiConfig,
+                 dk_config: configfile.DigikeyBaseConfig,
                  a_id: t.Optional[str] = None,
                  a_secret: t.Optional[str] = None,
                  # a_token_storage_path: t.Optional[str] = None,

--- a/digikey/oauth/oauth2.py
+++ b/digikey/oauth/oauth2.py
@@ -19,7 +19,7 @@ from digikey import configfile
 
 CA_CERT = 'digikey-api.pem'
 TOKEN_STORAGE = 'token_storage.json'
-CONFIGURATION_TEMPORARY_PATH = '/tmp/dk_config'
+CERTIFICATION_TEMPORARY_PATH = '/tmp/dk_cert'
 
 AUTH_URL_V2 = 'https://sso.digikey.com/as/authorization.oauth2'
 TOKEN_URL_V2 = 'https://sso.digikey.com/as/token.oauth2'
@@ -37,26 +37,31 @@ logger = logging.getLogger(__name__)
 
 
 class Oauth2Token:
-    def __init__(self, token):
-        self._token = token
+    def __init__(self, config: configfile.DigikeyApiConfig):
+        self._config = config
 
     @property
     def access_token(self):
-        return self._token.get('access_token')
+        return self._config.get('access_token')
 
     @property
     def refresh_token(self):
-        return self._token.get('refresh_token')
+        return self._config.get('refresh_token')
 
     @property
     def expires(self):
-        return datetime.fromtimestamp(self._token.get('expires'), timezone.utc)
+        if self._config.get('expires') is not None:
+            return datetime.fromtimestamp(self._config.get('expires'), timezone.utc)
+        return None
 
     @property
     def type(self):
-        return self._token.get('token_type')
+        return self._config.get('token_type')
 
     def expired(self) -> bool:
+        expires = self.expires
+        if expires is None:
+            return True
         return datetime.now(timezone.utc) >= self.expires
 
     def get_authorization(self) -> str:
@@ -104,7 +109,7 @@ class TokenHandler:
     Functions used to handle Digikey oAuth
     """
     def __init__(self,
-                 dg_config: configfile.DigikeyApiConfig,
+                 dk_config: configfile.DigikeyApiConfig,
                  a_id: t.Optional[str] = None,
                  a_secret: t.Optional[str] = None,
                  # a_token_storage_path: t.Optional[str] = None,
@@ -126,8 +131,10 @@ class TokenHandler:
 
         logger.debug(f'Using API V{version}')
 
-        a_id = a_id or dg_config.get('client-id')
-        a_secret = a_secret or dg_config.get('client-secret')
+        self.dk_config = dk_config
+
+        a_id = a_id or self.dk_config.get('client-id')
+        a_secret = a_secret or self.dk_config.get('client-secret')
         if not a_id or not a_secret:
             raise ValueError(
                 'CLIENT ID and SECRET must be set. '
@@ -137,8 +144,9 @@ class TokenHandler:
 
         self._id = a_id
         self._secret = a_secret
-        self._storage_path = Path(CONFIGURATION_TEMPORARY_PATH)
-        self._token_storage_path = self._storage_path.joinpath(TOKEN_STORAGE)
+
+        self._storage_path = Path(CERTIFICATION_TEMPORARY_PATH)
+        # self._token_storage_path = self._storage_path.joinpath(TOKEN_STORAGE)
         self._ca_cert = self._storage_path.joinpath(CA_CERT)
 
     def __generate_certificate(self):
@@ -181,7 +189,9 @@ class TokenHandler:
 
         # Create epoch timestamp from expires in, with 1 minute margin
         token_json['expires'] = int(token_json['expires_in']) + datetime.now(timezone.utc).timestamp() - 60
-        return token_json
+        # TODO: Perhaps expand out for loop to only write what's nessesary
+        for key in token_json:
+            self.dk_config.set(key, token_json[key])
 
     def __refresh_token(self, refresh_token: str):
         headers = {'user-agent': f'{UserAgent().firefox}',
@@ -207,12 +217,15 @@ class TokenHandler:
 
         # Create epoch timestamp from expires in, with 1 minute margin
         token_json['expires'] = int(token_json['expires_in']) + datetime.now(timezone.utc).timestamp() - 60
-        return token_json
+        # TODO: Perhaps expand out for loop to only write what's nessesary
+        for key in token_json:
+            self.dk_config.set(key, token_json[key])
 
-    def save(self, json_data):
-        with open(self._token_storage_path, 'w') as f:
-            json.dump(json_data, f)
-            logger.debug('Saved token to: {}'.format(self._token_storage_path))
+    def save(self):
+        # with open(self._token_storage_path, 'w') as f:
+        #     json.dump(json_data, f)
+        #     logger.debug('Saved token to: {}'.format(self._token_storage_path))
+        self.dk_config.save()
 
     def get_access_token(self) -> Oauth2Token:
         """
@@ -224,29 +237,28 @@ class TokenHandler:
         """
 
         # Check if a token already exists on the storage
-        token_json = None
-        try:
-            with open(self._token_storage_path, 'r') as f:
-                token_json = json.load(f)
-        except (EnvironmentError, JSONDecodeError):
-            logger.warning('Oauth2 token storage does not exist or malformed, creating new.')
+        # token_json = None
+        # try:
+        #     with open(self._token_storage_path, 'r') as f:
+        #         token_json = json.load(f)
+        # except (EnvironmentError, JSONDecodeError):
+        #     logger.warning('Oauth2 token storage does not exist or malformed, creating new.')
 
-        token = None
-        if token_json is not None:
-            token = Oauth2Token(token_json)
+        token_config = Oauth2Token(self.dk_config)
+        needs_authorization_token = False
 
         # Try to refresh the credentials with the stores refresh token
-        if token is not None and token.expired():
+        if token_config.expired():
             try:
-                logger.debug(f'REFRESH - Current token is stale, refresh using: {token.refresh_token}')
-                token_json = self.__refresh_token(token.refresh_token)
-                self.save(token_json)
+                logger.debug(f'REFRESH - Current token is stale, refresh using: {token_config.refresh_token}')
+                self.__refresh_token(token_config.refresh_token)
+                self.save()
             except DigikeyOauthException:
                 logger.error('REFRESH - Failed to use refresh token, starting new authorization flow.')
-                token_json = None
+                needs_authorization_token = True
 
         # Obtain new credentials using the Oauth flow if no token stored or refresh fails
-        if token_json is None:
+        if needs_authorization_token is True:
             open_new(self.__build_authorization_url())
             filename = self.__generate_certificate()
             httpd = HTTPServer(
@@ -269,9 +281,9 @@ class TokenHandler:
                 logger.error('Cannot remove temporary certificates: {}'.format(e))
 
             # Get the acccess token from the auth code
-            token_json = self.__exchange_for_token(httpd.auth_code)
+            self.__exchange_for_token(httpd.auth_code)
 
             # Save the newly obtained credentials to the filesystem
-            self.save(token_json)
+            self.save()
 
-        return Oauth2Token(token_json)
+        return Oauth2Token(self.dk_config)

--- a/digikey/oauth/oauth2.py
+++ b/digikey/oauth/oauth2.py
@@ -15,9 +15,11 @@ from certauth.certauth import CertificateAuthority
 from fake_useragent import UserAgent
 
 from digikey.exceptions import DigikeyOauthException
+from digikey import configfile
 
 CA_CERT = 'digikey-api.pem'
 TOKEN_STORAGE = 'token_storage.json'
+CONFIGURATION_TEMPORARY_PATH = '/tmp/dk_config'
 
 AUTH_URL_V2 = 'https://sso.digikey.com/as/authorization.oauth2'
 TOKEN_URL_V2 = 'https://sso.digikey.com/as/token.oauth2'
@@ -102,9 +104,10 @@ class TokenHandler:
     Functions used to handle Digikey oAuth
     """
     def __init__(self,
+                 dg_config: configfile.DigikeyApiConfig,
                  a_id: t.Optional[str] = None,
                  a_secret: t.Optional[str] = None,
-                 a_token_storage_path: t.Optional[str] = None,
+                 # a_token_storage_path: t.Optional[str] = None,
                  version: int = 2,
                  sandbox: bool = False):
 
@@ -123,8 +126,8 @@ class TokenHandler:
 
         logger.debug(f'Using API V{version}')
 
-        a_id = a_id or os.getenv('DIGIKEY_CLIENT_ID')
-        a_secret = a_secret or os.getenv('DIGIKEY_CLIENT_SECRET')
+        a_id = a_id or dg_config.get('client-id')
+        a_secret = a_secret or dg_config.get('client-secret')
         if not a_id or not a_secret:
             raise ValueError(
                 'CLIENT ID and SECRET must be set. '
@@ -132,17 +135,9 @@ class TokenHandler:
                 'as an environment variable, or pass your keys directly to the client.'
             )
 
-        a_token_storage_path = a_token_storage_path or os.getenv('DIGIKEY_STORAGE_PATH')
-        if not a_token_storage_path or not Path(a_token_storage_path).exists():
-            raise ValueError(
-                'STORAGE PATH must be set and must exist.'
-                'Set "DIGIKEY_STORAGE_PATH" as an environment variable, '
-                'or pass your keys directly to the client.'
-            )
-
         self._id = a_id
         self._secret = a_secret
-        self._storage_path = Path(a_token_storage_path)
+        self._storage_path = Path(CONFIGURATION_TEMPORARY_PATH)
         self._token_storage_path = self._storage_path.joinpath(TOKEN_STORAGE)
         self._ca_cert = self._storage_path.joinpath(CA_CERT)
 

--- a/digikey/v3/api.py
+++ b/digikey/v3/api.py
@@ -27,17 +27,13 @@ class DigikeyAPI:
             digikey.v3.batchproductdetails: digikey.v3.batchproductdetails.BatchSearchApi
         }
 
-        def __init__(self, config_file: digikey.configfile.DigikeyApiConfig, is_sandbox: bool = False):
+        def __init__(self, config_file: digikey.configfile.DigikeyBaseConfig, is_sandbox: bool = False):
             self.sandbox = is_sandbox
             self.apiname = None
             self._api_instance = None
             self.wrapped_function = None
             self.x_digikey_client_id = None
             self.config = config_file
-
-            # Return quietly if no clientid has been set to prevent errors when importing the module
-            # if os.getenv('DIGIKEY_CLIENT_ID') is None or os.getenv('DIGIKEY_CLIENT_SECRET') is None:
-                # raise DigikeyError('Please provide a valid DIGIKEY_CLIENT_ID and DIGIKEY_CLIENT_SECRET in your env setup')
 
             # Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
             # configuration.api_key_prefix['X-DIGIKEY-Client-Id'] = 'Bearer'
@@ -120,8 +116,8 @@ class DigikeyAPI:
             except ApiException as e:
                 logger.error(f'Exception when calling {self.wrapped_function}: {e}')
 
-    def __init__(self, config_file, is_sandbox: bool = False):
-        self.config = digikey.configfile.DigikeyApiConfig(config_file)
+    def __init__(self, config_constructor: digikey.configfile.DigikeyBaseConfig, is_sandbox: bool = False):
+        self.config = config_constructor
         self.client = self.DigikeyApiWrapper(self.config, is_sandbox)
 
     def needs_client_id(self) -> bool:

--- a/digikey/v3/api.py
+++ b/digikey/v3/api.py
@@ -2,6 +2,7 @@ import os
 import logging
 from distutils.util import strtobool
 import digikey.oauth.oauth2
+import digikey.configfile
 from digikey.exceptions import DigikeyError
 from digikey.v3.productinformation import (KeywordSearchRequest, KeywordSearchResponse, ProductDetails, DigiReelPricing,
                                            ManufacturerProductDetailsRequest)
@@ -12,10 +13,8 @@ from digikey.v3.batchproductdetails import (BatchProductDetailsRequest, BatchPro
 logger = logging.getLogger(__name__)
 
 
-class DigikeyApiWrapper(object):
-    def __init__(self, wrapped_function, module):
-        self.sandbox = False
-
+class DigikeyAPI:
+    class DigikeyApiWrapper(object):
         apinames = {
             digikey.v3.productinformation: 'Search',
             digikey.v3.ordersupport: 'OrderDetails',
@@ -28,144 +27,183 @@ class DigikeyApiWrapper(object):
             digikey.v3.batchproductdetails: digikey.v3.batchproductdetails.BatchSearchApi
         }
 
-        apiname = apinames[module]
-        apiclass = apiclasses[module]
+        def __init__(self, config_file: digikey.configfile.DigikeyApiConfig, is_sandbox: bool = False):
+            self.sandbox = is_sandbox
+            self.apiname = None
+            self._api_instance = None
+            self.wrapped_function = None
+            self.x_digikey_client_id = None
+            self.config = config_file
 
-        # Configure API key authorization: apiKeySecurity
-        configuration = module.Configuration()
-        configuration.api_key['X-DIGIKEY-Client-Id'] = os.getenv('DIGIKEY_CLIENT_ID')
+            # Return quietly if no clientid has been set to prevent errors when importing the module
+            # if os.getenv('DIGIKEY_CLIENT_ID') is None or os.getenv('DIGIKEY_CLIENT_SECRET') is None:
+                # raise DigikeyError('Please provide a valid DIGIKEY_CLIENT_ID and DIGIKEY_CLIENT_SECRET in your env setup')
 
-        # Return quietly if no clientid has been set to prevent errors when importing the module
-        if os.getenv('DIGIKEY_CLIENT_ID') is None or os.getenv('DIGIKEY_CLIENT_SECRET') is None:
-            raise DigikeyError('Please provide a valid DIGIKEY_CLIENT_ID and DIGIKEY_CLIENT_SECRET in your env setup')
+            # Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+            # configuration.api_key_prefix['X-DIGIKEY-Client-Id'] = 'Bearer'
 
-        # Use normal API by default, if DIGIKEY_CLIENT_SANDBOX is True use sandbox API
-        configuration.host = 'https://api.digikey.com/' + apiname + '/v3'
-        try:
-            if bool(strtobool(os.getenv('DIGIKEY_CLIENT_SANDBOX'))):
-                configuration.host = 'https://sandbox-api.digikey.com/' + apiname + '/v3'
-                self.sandbox = True
-        except (ValueError, AttributeError):
-            pass
+            self._digikeyApiToken = None
+            self.authorization = None
 
-        # Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
-        # configuration.api_key_prefix['X-DIGIKEY-Client-Id'] = 'Bearer'
+        def get_authorization(self):
+            """
+                Function that get Oauth2 authorization. This is not implement in __init__ to give the user
+                a chance to set the client secret and client id if it's not in the config file already
+            """
+            # Configure OAuth2 access token for authorization: oauth2AccessCodeSecurity
+            self._digikeyApiToken = digikey.oauth.oauth2.TokenHandler(self.config, version=3, sandbox=self.sandbox).get_access_token()
 
-        # Configure OAuth2 access token for authorization: oauth2AccessCodeSecurity
-        self._digikeyApiToken = digikey.oauth.oauth2.TokenHandler(version=3, sandbox=self.sandbox).get_access_token()
-        configuration.access_token = self._digikeyApiToken.access_token
+            # Populate reused ids
+            self.authorization = self._digikeyApiToken.get_authorization()
 
-        # create an instance of the API class
-        self._api_instance = apiclass(module.ApiClient(configuration))
+        def change_api(self, wrapped_function, module):
+            apiname = self.apinames[module]
+            apiclass = self.apiclasses[module]
+            # Only change the API when it's different than the current API
+            if self.apiname != apiname:
 
-        # Populate reused ids
-        self.authorization = self._digikeyApiToken.get_authorization()
-        self.x_digikey_client_id = os.getenv('DIGIKEY_CLIENT_ID')
+                if self.config.get('client-id') is None or self.config.get('client-secret') is None:
+                    raise DigikeyError('Please provide a valid DIGIKEY_CLIENT_ID and DIGIKEY_CLIENT_SECRET in your env setup')
 
-        self.wrapped_function = wrapped_function
+                if self._digikeyApiToken is None:
+                    self.get_authorization()
 
-    @staticmethod
-    def _remaining_requests(header, api_limits):
-        try:
-            rate_limit = header['X-RateLimit-Limit']
-            rate_limit_rem = header['X-RateLimit-Remaining']
+                self.apiname = apiname
+                self.x_digikey_client_id = self.config.get('client-id')
 
-            if api_limits is not None and type(api_limits) == dict:
-                api_limits['api_requests_limit'] = int(rate_limit)
-                api_limits['api_requests_remaining'] = int(rate_limit_rem)
+                # Configure API key authorization: apiKeySecurity
+                configuration = module.Configuration()
+                configuration.api_key['X-DIGIKEY-Client-Id'] = self.config.get('client-id')
 
-            logger.debug('Requests remaining: [{}/{}]'.format(rate_limit_rem, rate_limit))
-        except (KeyError, ValueError) as e:
-            logger.debug(f'No api limits returned -> {e.__class__.__name__}: {e}')
-            if api_limits is not None and type(api_limits) == dict:
-                api_limits['api_requests_limit'] = None
-                api_limits['api_requests_remaining'] = None
+                # Use normal API by default, if DIGIKEY_CLIENT_SANDBOX is True use sandbox API
+                configuration.host = 'https://api.digikey.com/' + apiname + '/v3'
+                try:
+                    if self.sandbox:
+                        configuration.host = 'https://sandbox-api.digikey.com/' + apiname + '/v3'
+                except (ValueError, AttributeError):
+                    pass
 
-    def call_api_function(self, *args, **kwargs):
-        try:
-            # If optional api_limits mutable object is passed use it to store API limits
-            api_limits = kwargs.pop('api_limits', None)
+                configuration.access_token = self._digikeyApiToken.access_token
 
-            func = getattr(self._api_instance, self.wrapped_function)
-            logger.debug(f'CALL wrapped -> {func.__qualname__}')
-            api_response = func(*args, self.authorization, self.x_digikey_client_id, **kwargs)
-            self._remaining_requests(api_response[2], api_limits)
+                # create an instance of the API class
+                self._api_instance = apiclass(module.ApiClient(configuration))
+            self.wrapped_function = wrapped_function
 
-            return api_response[0]
-        except ApiException as e:
-            logger.error(f'Exception when calling {self.wrapped_function}: {e}')
+        @staticmethod
+        def _remaining_requests(header, api_limits):
+            try:
+                rate_limit = header['X-RateLimit-Limit']
+                rate_limit_rem = header['X-RateLimit-Remaining']
 
+                if api_limits is not None and type(api_limits) == dict:
+                    api_limits['api_requests_limit'] = int(rate_limit)
+                    api_limits['api_requests_remaining'] = int(rate_limit_rem)
 
-def keyword_search(*args, **kwargs) -> KeywordSearchResponse:
-    client = DigikeyApiWrapper('keyword_search_with_http_info', digikey.v3.productinformation)
+                logger.debug('Requests remaining: [{}/{}]'.format(rate_limit_rem, rate_limit))
+            except (KeyError, ValueError) as e:
+                logger.debug(f'No api limits returned -> {e.__class__.__name__}: {e}')
+                if api_limits is not None and type(api_limits) == dict:
+                    api_limits['api_requests_limit'] = None
+                    api_limits['api_requests_remaining'] = None
 
-    if 'body' in kwargs and type(kwargs['body']) == KeywordSearchRequest:
-        logger.info(f'Search for: {kwargs["body"].keywords}')
-        logger.debug('CALL -> keyword_search')
-        return client.call_api_function(*args, **kwargs)
-    else:
-        raise DigikeyError('Please provide a valid KeywordSearchRequest argument')
+        def call_api_function(self, *args, **kwargs):
+            try:
+                # If optional api_limits mutable object is passed use it to store API limits
+                api_limits = kwargs.pop('api_limits', None)
 
+                func = getattr(self._api_instance, self.wrapped_function)
+                logger.debug(f'CALL wrapped -> {func.__qualname__}')
+                api_response = func(*args, self.authorization, self.x_digikey_client_id, **kwargs)
+                self._remaining_requests(api_response[2], api_limits)
 
-def product_details(*args, **kwargs) -> ProductDetails:
-    client = DigikeyApiWrapper('product_details_with_http_info', digikey.v3.productinformation)
+                return api_response[0]
+            except ApiException as e:
+                logger.error(f'Exception when calling {self.wrapped_function}: {e}')
 
-    if len(args):
-        logger.info(f'Get product details for: {args[0]}')
-        return client.call_api_function(*args, **kwargs)
+    def __init__(self, config_file, is_sandbox: bool = False):
+        self.config = digikey.configfile.DigikeyApiConfig(config_file)
+        self.client = self.DigikeyApiWrapper(self.config, is_sandbox)
 
+    def needs_client_id(self) -> bool:
+        if self.config.get('client-id') is None:
+            return True
+        return False
 
-def digi_reel_pricing(*args, **kwargs) -> DigiReelPricing:
-    client = DigikeyApiWrapper('digi_reel_pricing_with_http_info', digikey.v3.productinformation)
+    def needs_client_secret(self) -> bool:
+        if self.config.get('client-secret') is None:
+            return True
+        return False
 
-    if len(args):
-        logger.info(f'Calculate the DigiReel pricing for {args[0]} with quantity {args[1]}')
-        return client.call_api_function(*args, **kwargs)
+    def set_client_info(self, client_id=None, client_secret=None):
+        if client_id is not None:
+            self.config.set('client-id', client_id)
+        if client_secret is not None:
+            self.config.set('client-secret', client_secret)
+        self.config.save()
 
+    def keyword_search(self, *args, **kwargs) -> KeywordSearchResponse:
+        self.client.change_api('keyword_search_with_http_info', digikey.v3.productinformation)
 
-def suggested_parts(*args, **kwargs) -> ProductDetails:
-    client = DigikeyApiWrapper('suggested_parts_with_http_info', digikey.v3.productinformation)
+        if 'body' in kwargs and type(kwargs['body']) == KeywordSearchRequest:
+            logger.info(f'Search for: {kwargs["body"].keywords}')
+            logger.debug('CALL -> keyword_search')
+            return self.client.call_api_function(*args, **kwargs)
+        else:
+            raise DigikeyError('Please provide a valid KeywordSearchRequest argument')
 
-    if len(args):
-        logger.info(f'Retrieve detailed product information and two suggested products for: {args[0]}')
-        return client.call_api_function(*args, **kwargs)
+    def product_details(self, *args, **kwargs) -> ProductDetails:
+        self.client.change_api('product_details_with_http_info', digikey.v3.productinformation)
 
+        if len(args):
+            logger.info(f'Get product details for: {args[0]}')
+            return self.client.call_api_function(*args, **kwargs)
 
-def manufacturer_product_details(*args, **kwargs) -> KeywordSearchResponse:
-    client = DigikeyApiWrapper('manufacturer_product_details_with_http_info', digikey.v3.productinformation)
+    def digi_reel_pricing(self, *args, **kwargs) -> DigiReelPricing:
+        self.client.change_api('digi_reel_pricing_with_http_info', digikey.v3.productinformation)
 
-    if 'body' in kwargs and type(kwargs['body']) == ManufacturerProductDetailsRequest:
-        logger.info(f'Search for: {kwargs["body"].manufacturer_product}')
-        return client.call_api_function(*args, **kwargs)
-    else:
-        raise DigikeyError('Please provide a valid ManufacturerProductDetailsRequest argument')
+        if len(args):
+            logger.info(f'Calculate the DigiReel pricing for {args[0]} with quantity {args[1]}')
+            return self.client.call_api_function(*args, **kwargs)
 
+    def suggested_parts(self, *args, **kwargs) -> ProductDetails:
+        self.client.change_api('suggested_parts_with_http_info', digikey.v3.productinformation)
 
-def status_salesorder_id(*args, **kwargs) -> OrderStatusResponse:
-    client = DigikeyApiWrapper('status_salesorder_id_get_with_http_info', digikey.v3.ordersupport)
+        if len(args):
+            logger.info(f'Retrieve detailed product information and two suggested products for: {args[0]}')
+            return self.client.call_api_function(*args, **kwargs)
 
-    if len(args):
-        logger.info(f'Get order details for: {args[0]}')
-        return client.call_api_function(*args, **kwargs)
+    def manufacturer_product_details(self, *args, **kwargs) -> KeywordSearchResponse:
+        self.client.change_api('manufacturer_product_details_with_http_info', digikey.v3.productinformation)
 
+        if 'body' in kwargs and type(kwargs['body']) == ManufacturerProductDetailsRequest:
+            logger.info(f'Search for: {kwargs["body"].manufacturer_product}')
+            return self.client.call_api_function(*args, **kwargs)
+        else:
+            raise DigikeyError('Please provide a valid ManufacturerProductDetailsRequest argument')
 
-def salesorder_history(*args, **kwargs) -> [SalesOrderHistoryItem]:
-    client = DigikeyApiWrapper('history_get_with_http_info', digikey.v3.ordersupport)
+    def status_salesorder_id(self, *args, **kwargs) -> OrderStatusResponse:
+        self.client.change_api('status_salesorder_id_get_with_http_info', digikey.v3.ordersupport)
 
-    if 'start_date' in kwargs and type(kwargs['start_date']) == str \
-            and 'end_date' in kwargs and type(kwargs['end_date']) == str:
-        logger.info(f'Searching for orders in date range ' + kwargs['start_date'] + ' to ' + kwargs['end_date'])
-        return client.call_api_function(*args, **kwargs)
-    else:
-        raise DigikeyError('Please provide valid start_date and end_date strings')
+        if len(args):
+            logger.info(f'Get order details for: {args[0]}')
+            return self.client.call_api_function(*args, **kwargs)
 
+    def salesorder_history(self, *args, **kwargs) -> [SalesOrderHistoryItem]:
+        self.client.change_api('history_get_with_http_info', digikey.v3.ordersupport)
 
-def batch_product_details(*args, **kwargs) -> BatchProductDetailsResponse:
-    client = DigikeyApiWrapper('batch_product_details_with_http_info', digikey.v3.batchproductdetails)
+        if 'start_date' in kwargs and type(kwargs['start_date']) == str \
+                and 'end_date' in kwargs and type(kwargs['end_date']) == str:
+            logger.info(f'Searching for orders in date range ' + kwargs['start_date'] + ' to ' + kwargs['end_date'])
+            return self.client.call_api_function(*args, **kwargs)
+        else:
+            raise DigikeyError('Please provide valid start_date and end_date strings')
 
-    if 'body' in kwargs and type(kwargs['body']) == BatchProductDetailsRequest:
-        logger.info(f'Batch product search: {kwargs["body"].products}')
-        logger.debug('CALL -> batch_product_details')
-        return client.call_api_function(*args, **kwargs)
-    else:
-        raise DigikeyError('Please provide a valid BatchProductDetailsRequest argument')
+    def batch_product_details(self, *args, **kwargs) -> BatchProductDetailsResponse:
+        self.client.change_api('batch_product_details_with_http_info', digikey.v3.batchproductdetails)
+
+        if 'body' in kwargs and type(kwargs['body']) == BatchProductDetailsRequest:
+            logger.info(f'Batch product search: {kwargs["body"].products}')
+            logger.debug('CALL -> batch_product_details')
+            return self.client.call_api_function(*args, **kwargs)
+        else:
+            raise DigikeyError('Please provide a valid BatchProductDetailsRequest argument')


### PR DESCRIPTION
This PR adds a method of setting and saving this package's settings (like `client-id` and `refresh-token`) without needing to use OS environment variables. 
Main changes includes:
- Added all API fucntions (for V3) under a `DigikeyAPI` class. 
- Added a configuration class which is fed into `DigikeyAPI`. This class includes all necessary functions to be able to save and get configurations. The parent class is `DigikeyBaseConfig`, which that one does nothing but outline what functions any child class must override. As of right now I've only 1 config storage method/kind under `DigikeyJsonConfig`, which stores and retrieves configurations in a JSON file.
- Added the functions `needs_client_id()`, `needs_client_secret()`, and `set_client_info()` to allow the user to know if said info are needed and to be able to give them to this library.

TODO: 
- [ ] Document `DigikeyBaseConfig` further to specify how a user can create their own (for example if someone wants to store said settings inside a database).
- [ ] Document the new changes to how to call up the API
- [ ] Change V2's code to allow for the new configuration:
  - Is this even worth it, or is it better to drop V2 support?