### PR TITLE
Use static user agent

### DIFF
--- a/digikey/oauth/oauth2.py
+++ b/digikey/oauth/oauth2.py
@@ -12,7 +12,6 @@ from webbrowser import open_new
 
 import requests
 from certauth.certauth import CertificateAuthority
-from fake_useragent import UserAgent
 
 from digikey.exceptions import DigikeyOauthException
 

--- a/digikey/oauth/oauth2.py
+++ b/digikey/oauth/oauth2.py
@@ -31,6 +31,8 @@ TOKEN_URL_V3_SB = 'https://sandbox-api.digikey.com/v1/oauth2/token'
 REDIRECT_URI = 'https://localhost:8139/digikey_callback'
 PORT = 8139
 
+USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:93.0) Gecko/20100101 Firefox/93.0"
+
 logger = logging.getLogger(__name__)
 
 
@@ -161,7 +163,7 @@ class TokenHandler:
         return url
 
     def __exchange_for_token(self, code):
-        headers = {'user-agent': f'{UserAgent().firefox}',
+        headers = {'user-agent': USER_AGENT,
                    'Content-type': 'application/x-www-form-urlencoded'
                    }
         post_data = {'grant_type': 'authorization_code',
@@ -189,7 +191,7 @@ class TokenHandler:
         return token_json
 
     def __refresh_token(self, refresh_token: str):
-        headers = {'user-agent': f'{UserAgent().firefox}',
+        headers = {'user-agent': USER_AGENT,
                    'Content-type': 'application/x-www-form-urlencoded'
                    }
         post_data = {'grant_type': 'refresh_token',

--- a/digikey/v2/client.py
+++ b/digikey/v2/client.py
@@ -5,7 +5,6 @@ import typing as t
 from pathlib import Path
 
 import requests
-from fake_useragent import UserAgent
 
 from digikey.v2 import models
 from digikey.decorators import retry
@@ -15,7 +14,7 @@ from digikey.oauth.oauth2 import TokenHandler
 logger = logging.getLogger(__name__)
 
 DEFAULT_BASE_URL = 'https://api.digikey.com/services/partsearch/v2'
-
+USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:93.0) Gecko/20100101 Firefox/93.0"
 
 class DigikeyClient(object):
     """Client object for Digikey API
@@ -63,7 +62,7 @@ class DigikeyClient(object):
                  path: str,
                  data: t.Dict[str, t.Any]=None
                  ) -> t.Any:
-        headers = {'user-agent': f'{UserAgent().firefox}',
+        headers = {'user-agent': USER_AGENT,
                    'x-ibm-client-id': self._id,
                    'authorization': self.oauth2.get_authorization()}
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 inflection
 certauth
-fake-useragent
 requests
 retrying
 schematics

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,6 @@ setuptools.setup(
     install_requires=[
         'requests>=2.22.0',
         'retrying>=1.3.3',
-        'fake-useragent>=0.1.11',
         'schematics>=2.1.0',
         'inflection>=0.3.1',
         'certauth>=1.3.0',


### PR DESCRIPTION
Fixes #11, or part of it anyway.

This PR removes the dependency on fake-useragent, which is in my opinion not a great dependency to have. It relies on an external server(s), and if you look at its [issues](https://github.com/hellysmile/fake-useragent/issues), you'll lots of people have problems because that server can go down.

I don't think using this static user agent will cause any issue. It's the most current Firefox one right now, but even as it goes out of date it would be unusual for Digikey to reject it.