### PR TITLE
inline strtobool due to distutils removal in Python 3.12

### DIFF
--- a/digikey/v3/api.py
+++ b/digikey/v3/api.py
@@ -1,6 +1,5 @@
 import os
 import logging
-from distutils.util import strtobool
 import digikey.oauth.oauth2
 from digikey.exceptions import DigikeyError
 from digikey.v3.productinformation import (KeywordSearchRequest, KeywordSearchResponse, ProductDetails, DigiReelPricing,
@@ -179,3 +178,20 @@ def batch_product_details(*args, **kwargs) -> BatchProductDetailsResponse:
         return client.call_api_function(*args, **kwargs)
     else:
         raise DigikeyError('Please provide a valid BatchProductDetailsRequest argument')
+
+
+def strtobool(val):
+    """Convert a string representation of truth to true (1) or false (0).
+    True values are 'y', 'yes', 't', 'true', 'on', and '1'; false values
+    are 'n', 'no', 'f', 'false', 'off', and '0'.  Raises ValueError if
+    'val' is anything else.
+
+	Copy from distutils.utils, which was removed in Python 3.12
+    """
+    val = val.lower()
+    if val in ('y', 'yes', 't', 'true', 'on', '1'):
+        return 1
+    elif val in ('n', 'no', 'f', 'false', 'off', '0'):
+        return 0
+    else:
+        raise ValueError("invalid truth value %r" % (val,))


### PR DESCRIPTION
The library is not compatible with Python 3.12 (and future versions), due to the removal of the distutils module in [PEP 632](https://peps.python.org/pep-0632/). This change inlines the function into the code base.